### PR TITLE
Caching of Network Peers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
 **/.DS_Store
-peers.db
+nodes.db
 masternode.conf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 **/.DS_Store
+peers.db
+masternode.conf

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ There is a coinconf generator included that can auto-generate settings for most 
     	The string to use for the sentinel version number (i.e. 1.20.0) (default "0.0.0")
   -user_agent
       The user agent string to connect to remote peers with.
+  -db_path
+      The destination for database storage (default path is ./peers.db)
 ```
 
 ## Building (using Docker)

--- a/cmd/phantom/main.go
+++ b/cmd/phantom/main.go
@@ -34,7 +34,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/jackkdev/phantom/pkg/storage"
+	"github.com/breakcrypto/phantom/pkg/storage"
 	"log"
 	"github.com/breakcrypto/phantom/pkg/socket/wire"
 	"github.com/breakcrypto/phantom/pkg/phantom"

--- a/cmd/phantom/main.go
+++ b/cmd/phantom/main.go
@@ -59,6 +59,8 @@ var coinCon phantom.CoinConf
 var dbPath string
 var userAgent string
 
+var cachedPeers error
+
 const VERSION = "0.0.4"
 
 func main() {
@@ -145,6 +147,8 @@ func main() {
 	} else {
 		log.Println("Database was initialised:", db)
 	}
+
+	cachedPeers = storage.LoadPeersFromDB(db)
 
 	magicMsgNewLine = true
 
@@ -321,17 +325,17 @@ func getNextPeer(connectionSet map[string]*phantom.PingerConnection, peerSet map
 			//we have a peer that isn't in the conncetion list return it
 			returnValue = peerSet[peer]
 
-			//remove the peer from the connection list
-			delete(peerSet, peer)
-
-			log.Println("Found new peer: ", peer)
-
 			// Cache peers
-			db, err := storage.InitialiseDB("peers.dat")
+			db, err := storage.InitialiseDB("peers.db")
 			if err != nil {
 				log.Fatal(err)
 			}
 			err = storage.CachePeerToDB(db, peer)
+
+			//remove the peer from the connection list
+			delete(peerSet, peer)
+
+			log.Println("Found new peer: ", peer)
 
 			return returnValue, nil
 		}

--- a/cmd/phantom/main.go
+++ b/cmd/phantom/main.go
@@ -316,7 +316,7 @@ func processNewAddresses(addrChannel chan wire.NetAddress, peerSet map[string]wi
 
 }
 
-func getNextPeer(connectionSet map[string]*phantom.PingerConnection, peerSet map[string]wire.NetAddress) (returnValue wire.NetAddress, err error) {
+func getNextPeer(peerSet map[string]wire.NetAddress) (returnValue wire.NetAddress, err error) {
 
 	// load the database
 	db, err := storage.SetupDB()
@@ -329,19 +329,25 @@ func getNextPeer(connectionSet map[string]*phantom.PingerConnection, peerSet map
 	list, err := storage.FetchPeers(db)
 	fmt.Println(list)
 
-	for peer := range peerSet {
-		if _, ok := connectionSet[peer]; !ok {
-			//we have a peer that isn't in the conncetion list return it
-			returnValue = peerSet[peer]
-
-			//remove the peer from the connection list
-			delete(peerSet, peer)
-
-			log.Println("Found new peer: ", peer)
-
-			return returnValue, nil
-		}
+	for i := 0; i <= len(list); i++ {
+		returnValue = peerSet[list[i]]
 	}
+
+	// LEFT FOR NOW UNTIL FURTHER TESTING IS COMPLETE
+	//for peer := range peerSet {
+	//	if _, ok := connectionSet[peer]; !ok {
+	//		//we have a peer that isn't in the conncetion list return it
+	//		returnValue = peerSet[peer]
+	//
+	//		//remove the peer from the connection list
+	//		delete(peerSet, peer)
+	//
+	//		log.Println("Found new peer: ", peer)
+	//
+	//		return returnValue, nil
+	//	}
+	//}
+
 	return returnValue, errors.New("No peers found.")
 }
 
@@ -402,7 +408,7 @@ func sendPings(connectionSet map[string]*phantom.PingerConnection, peerSet map[s
 			for i := 0; i < int(maxConnections) - len(connectionSet); i++ {
 
 				//spawn off a new connection
-				peer, err := getNextPeer(connectionSet, peerSet)
+				peer, err := getNextPeer(peerSet)
 
 				if err != nil {
 					log.Println("No new peers found.")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -52,3 +52,17 @@ func CachePeerToDB(db *bolt.DB, peer string) error {
 	log.Println("Peer added to cache", entry)
 	return err
 }
+
+func LoadPeersFromDB(db *bolt.DB) error {
+	err := db.View(func(tx *bolt.Tx) error {
+		peers := tx.Bucket([]byte("peers")).Get([]byte("peer"))
+		log.Println("Peers: %s\n", peers)
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,0 +1,54 @@
+package storage
+
+import(
+	"encoding/json"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"log"
+)
+
+func InitialiseDB(path string) (*bolt.DB, error) {
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		peerBucket, err := tx.CreateBucketIfNotExists([]byte("peers"))
+		if err != nil {
+			return fmt.Errorf("Could not create peers bucket: %v", err)
+		} else {
+			log.Println("Bucket created:", peerBucket)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	log.Println("Database successfully initialised...")
+
+	return db, nil
+}
+
+func CachePeerToDB(db *bolt.DB, peer string) error {
+	entry := peer
+	entryBytes, err := json.Marshal(entry)
+
+	if err != nil {
+		return err
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		err := tx.Bucket([]byte("peers")).Put([]byte("peer"), (entryBytes))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	log.Println("Peer added to cache", entry)
+	return err
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -50,19 +50,23 @@ func CachePeerToDB(db *bolt.DB, peer string) error {
 	})
 
 	log.Println("Peer added to cache", entry)
+	defer db.Close()
+
 	return err
 }
 
 func LoadPeersFromDB(db *bolt.DB) error {
 	err := db.View(func(tx *bolt.Tx) error {
 		peers := tx.Bucket([]byte("peers")).Get([]byte("peer"))
-		log.Println("Peers: %s\n", peers)
+		log.Println("Peers:\n", string(peers))
 		return nil
 	})
 
 	if err != nil {
 		return err
 	}
+
+	defer db.Close()
 
 	return nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,6 +1,6 @@
 package storage
 
-import(
+import (
 	"encoding/json"
 	"fmt"
 	"github.com/boltdb/bolt"
@@ -14,11 +14,11 @@ func InitialiseDB(path string) (*bolt.DB, error) {
 	}
 
 	err = db.Update(func(tx *bolt.Tx) error {
-		peerBucket, err := tx.CreateBucketIfNotExists([]byte("peers"))
+		_, err := tx.CreateBucketIfNotExists([]byte("peers"))
 		if err != nil {
-			return fmt.Errorf("Could not create peers bucket: %v", err)
+			return fmt.Errorf("DB: Could not create peers bucket: %v", err)
 		} else {
-			log.Println("Bucket created:", peerBucket)
+			log.Println("DB: Bucket created was created")
 		}
 		return nil
 	})
@@ -27,7 +27,7 @@ func InitialiseDB(path string) (*bolt.DB, error) {
 		return nil, err
 	}
 
-	log.Println("Database successfully initialised...")
+	log.Println("DB: Successfully initialised...")
 
 	return db, nil
 }


### PR DESCRIPTION
For a bit of context, I read over the issue created here:

https://github.com/breakcrypto/phantom/issues/2

* Uses a simple key value database (BoltDB), instead of something like SQLite
* Each time a new peer appears that isn't in the connection list, the function is called to cache the peer into the DB.
* On daemon execution, a list of cached peers are shown

**Still a work in progress, but basic functionality is there and waiting to be improved on.**